### PR TITLE
(chore) restrict signin to nwplus emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist-ssr
 *.local
 .lighthouseci
+.env

--- a/src/components/features/auth/sign-in-button.tsx
+++ b/src/components/features/auth/sign-in-button.tsx
@@ -20,6 +20,9 @@ export function SignInButton({
     setLoading(true);
     try {
       const provider = new GoogleAuthProvider();
+      provider.setCustomParameters({
+        hd: "nwplus.io",
+      });
       await signInWithPopup(auth, provider);
     } catch (error) {
       console.error("Error signing in with Google:", error);


### PR DESCRIPTION
## Reason
<!--- Describe the motivation and purpose for this PR -->
Tried signing in with my personal email by accident and it redirected me back to the login page, thought it would be more intuitive to only allow nwplus emails to sign in.

## Explanation
<!--- Describe your changes! Include changes you made and screenshots/video if applicable -->
Pure frontend change to restrict logins to emails with the `nwplus.io` domain ([docs](https://developers.google.com/identity/openid-connect/openid-connect#hd-param)).

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->