### PR TITLE
chore: block npm and yarn installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "biome lint",
     "lint:write": "biome lint --write ./src",
     "lint:write:unsafe": "biome lint --write --unsafe ./src",
-    "check": "biome check"
+    "check": "biome check",
+    "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
     "@faker-js/faker": "^9.6.0",


### PR DESCRIPTION
## Reason
Because I always forget which package manager to use
![2025-06-15 at 10 53PM](https://github.com/user-attachments/assets/01d06024-3c0d-4713-acf7-c026b94a30e2)

## Explanation
Whenever `{non-pnpm package manager} install` is run, it'll block it and ask the user to run `pnpm install` instead.

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->