### PR TITLE
Saved queries

### DIFF
--- a/src/components/features/query/query-actions.tsx
+++ b/src/components/features/query/query-actions.tsx
@@ -100,13 +100,15 @@ export function QueryActions() {
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <button className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus:outline-none">
+                <button 
+                  type="button"
+                  className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-gray-100 focus:outline-none">
                   <MoreVertical className="h-5 w-5 text-gray-600" />
                   <span className="sr-only">More actions</span>
                 </button>
               </DropdownMenuTrigger>
             </TooltipTrigger>
-            <TooltipContent className="bg-gray-900 text-white border-gray-800">
+            <TooltipContent className="border-gray-800 bg-gray-900 text-white">
               <p>Actions</p>
             </TooltipContent>
           </Tooltip>

--- a/src/components/features/query/query-actions.tsx
+++ b/src/components/features/query/query-actions.tsx
@@ -1,0 +1,156 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { Download, FileBarChart, MoreVertical } from "lucide-react";
+import type { FlattenedApplicant } from "@/services/query";
+import { useQuery } from "@/providers/query-provider";
+
+/**
+ * Dropdown menu combining Export and Raffle actions
+ */
+export function QueryActions() {
+  const { selectedHackathon, tableData } = useQuery();
+  const [winner, setWinner] = useState<FlattenedApplicant | null>(null);
+
+  const handleExport = useCallback(() => {
+    if (tableData.length === 0) {
+      toast.error("No data to export");
+      return;
+    }
+
+    const headers = Object.keys(tableData[0]);
+    const csvContent = [
+      headers.join(","),
+      ...tableData.map((row) =>
+        headers
+          .map((header) => {
+            const value = row[header];
+            if (typeof value === "string" && (value.includes(",") || value.includes('"'))) {
+              return `"${value.replace(/"/g, '""')}"`;
+            }
+            return value;
+          })
+          .join(","),
+      ),
+    ].join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `${selectedHackathon}_applicants_${new Date().toISOString().split("T")[0]}.csv`,
+    );
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    
+    toast.success("CSV file downloaded successfully");
+  }, [tableData, selectedHackathon]);
+
+  const handleRaffle = useCallback(() => {
+    if (tableData.length === 0) {
+      toast.error("No applicants available for raffle");
+      return;
+    }
+
+    const eligibleApplicants = tableData.filter(
+      (applicant) => applicant.applicationStatus === "acceptedAndAttending",
+    );
+
+    if (eligibleApplicants.length === 0) {
+      toast.error("No eligible applicants (marked as acceptedAndAttending) for raffle");
+      return;
+    }
+
+    const randomIndex = Math.floor(Math.random() * eligibleApplicants.length);
+    setWinner(eligibleApplicants[randomIndex]);
+  }, [tableData]);
+
+  const hasData = tableData.length > 0;
+  const eligibleForRaffle = hasData && tableData.some(
+    (applicant) => applicant.applicationStatus === "acceptedAndAttending"
+  );
+
+  return (
+    <>
+      <TooltipProvider>
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus:outline-none">
+                  <MoreVertical className="h-5 w-5 text-gray-600" />
+                  <span className="sr-only">More actions</span>
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent className="bg-gray-900 text-white border-gray-800">
+              <p>Actions</p>
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem
+              onClick={handleExport}
+              disabled={!hasData}
+              className="cursor-pointer p-2"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Export CSV
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={handleRaffle}
+              disabled={!eligibleForRaffle}
+              className="cursor-pointer p-2"
+            >
+              <FileBarChart className="mr-2 h-4 w-4" />
+              Run Raffle
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TooltipProvider>
+
+      <Dialog open={!!winner} onOpenChange={() => setWinner(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>🎉 Raffle Winner!</DialogTitle>
+            <DialogDescription>
+              {winner && (
+                <div>
+                  <div>
+                    <strong>
+                      {winner.firstName} {winner.lastName}
+                    </strong>
+                  </div>
+                  <div>{winner.email}</div>
+                </div>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+} 

--- a/src/components/features/query/saved-queries.tsx
+++ b/src/components/features/query/saved-queries.tsx
@@ -1,0 +1,375 @@
+import { useState } from "react";
+import { PlusIcon, BookmarkIcon, SearchIcon, TagIcon, CalendarIcon, UserIcon, CodeIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useQuery } from "@/providers/query-provider";
+import type { FirebaseQuery } from "@/lib/firebase/types";
+
+interface SavedQueriesProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Converts a FirebaseQuery object into a human-readable query string
+ */
+function parseQueryToString(query: FirebaseQuery): string {
+  const parts: string[] = [];
+
+  if (query.selectedColumns.length > 0) {
+    parts.push(`SELECT ${query.selectedColumns.join(", ")}`);
+  }
+
+  parts.push("FROM applicants");
+
+  if (query.filterSelections.length > 0) {
+    const whereConditions = query.filterSelections.map((filter, index) => {
+      const operator = getFilterOperatorSymbol(filter.filterCondition);
+      const value = isNaN(Number(filter.filterValue)) 
+        ? `'${filter.filterValue}'` 
+        : filter.filterValue;
+      
+      let condition = `${filter.filterColumn} ${operator} ${value}`;
+      
+      if (index > 0) {
+        const logicalOp = filter.logicalOperator || 'AND';
+        condition = `${logicalOp} ${condition}`;
+      }
+      
+      return condition;
+    });
+    
+    parts.push(`WHERE ${whereConditions.join(" ")}`);
+  }
+
+  if (query.groupBySelection) {
+    parts.push(`GROUP BY ${query.groupBySelection.groupByColumn}`);
+    parts.push(`AGGREGATE ${query.groupBySelection.aggregationFunction}(${query.groupBySelection.aggregationColumn})`);
+  }
+
+  if (query.sorting.length > 0) {
+    const orderConditions = query.sorting.map(sort => 
+      `${sort.id} ${sort.desc ? 'DESC' : 'ASC'}`
+    );
+    parts.push(`ORDER BY ${orderConditions.join(", ")}`);
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Converts filter condition to operator symbol
+ */
+function getFilterOperatorSymbol(condition: string): string {
+  switch (condition) {
+    case "equals":
+      return "=";
+    case "not_equals":
+      return "!=";
+    case "greater_than":
+      return ">";
+    case "less_than":
+      return "<";
+    case "matches":
+      return "LIKE";
+    case "does_not_match":
+      return "NOT LIKE";
+    default:
+      return condition;
+  }
+}
+
+/**
+ * Dialog to display saved queries
+ */
+export function SavedQueries({ children }: SavedQueriesProps) {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedTab, setSelectedTab] = useState("browse");
+  
+  // TODO: replace with actual Firebase data
+  const [savedQueries] = useState<FirebaseQuery[]>([
+          {
+        id: "1",
+        description: "Blacklisted applicants",
+        selectedColumns: ["firstName", "school", "major", "totalScore"],
+        filterSelections: [
+          {
+            id: "f1",
+            filterColumn: "totalScore",
+            filterCondition: "less_than",
+            filterValue: "0",
+          },
+        ],
+        groupBySelection: undefined,
+        sorting: [],
+        createdAt: new Date("2024-01-15"),
+        updatedAt: new Date("2024-01-15"),
+        createdBy: "user123",
+        isPublic: true,
+        tags: ["applicants"],
+      },
+    {
+      id: "2", 
+      description: "All accepted applicants",
+      selectedColumns: ["firstName", "email", "major", "totalScore"],
+      filterSelections: [
+        {
+          id: "f3",
+          filterColumn: "applicationStatus",
+          filterCondition: "equals",
+          filterValue: "acceptedNoResponseYet",
+        },
+      ],
+      groupBySelection: undefined,
+      sorting: [{ id: "totalScore", desc: true }],
+      createdAt: new Date("2024-01-10"),
+      updatedAt: new Date("2024-01-12"),
+      createdBy: "user456",
+      isPublic: false,
+      tags: ["accepted", "final"],
+    },
+  ]);
+
+  const {
+    selectedColumns,
+    filterSelections,
+    groupBySelection,
+    sorting,
+    onColumnToggle,
+    onFilterAdd,
+    onFilterRemove,
+    onGroupByChange,
+    onSortingChange,
+  } = useQuery();
+
+  const filteredQueries = savedQueries.filter(query =>
+    query.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    query.tags?.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+
+  const handleApplyQuery = (query: FirebaseQuery) => {
+    filterSelections.forEach(filter => onFilterRemove(filter.id));
+    onGroupByChange(undefined);
+    onSortingChange([]);
+    
+    // TO-DO: need to optimize the provider to handle bulk updates more efficiently
+    query.filterSelections.forEach(filter => onFilterAdd(filter));
+    if (query.groupBySelection) {
+      onGroupByChange(query.groupBySelection);
+    }
+    onSortingChange(query.sorting);
+    
+    // TO-DO: need to add/remove columns to match the saved selection
+    const currentColumns = new Set(selectedColumns);
+    const targetColumns = new Set(query.selectedColumns);
+    
+    selectedColumns.forEach(col => {
+      if (!targetColumns.has(col)) {
+        onColumnToggle(col);
+      }
+    });
+    
+    query.selectedColumns.forEach(col => {
+      if (!currentColumns.has(col)) {
+        onColumnToggle(col);
+      }
+    });
+    
+    setOpen(false);
+  };
+
+  const handleSaveCurrentQuery = () => {
+    // TODO: Create a new FirebaseQuery from current state
+    console.log("Save current query:", {
+      selectedColumns,
+      filterSelections,
+      groupBySelection,
+      sorting,
+    });
+  };
+
+  const getCurrentQueryString = (): string => {
+    const currentQuery: FirebaseQuery = {
+      id: "current",
+      description: "Current Query",
+      selectedColumns,
+      filterSelections,
+      groupBySelection: groupBySelection || undefined,
+      sorting,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      createdBy: "current-user",
+      isPublic: false,
+    };
+    return parseQueryToString(currentQuery);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {children}
+      </DialogTrigger>
+      <DialogContent className="max-w-5xl max-h-[85vh] overflow-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <BookmarkIcon className="h-5 w-5" />
+            Saved Queries
+          </DialogTitle>
+          <DialogDescription>
+            Browse, apply, and manage your saved query configurations
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="flex-1 overflow-hidden">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="browse">Browse Queries</TabsTrigger>
+            <TabsTrigger value="create">Save Current</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="browse" className="flex-1 overflow-hidden">
+            <div className="space-y-4 h-full">
+              <div className="flex items-center gap-2">
+                <div className="relative flex-1">
+                  <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Search queries by description or tags..."
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    className="pl-10"
+                  />
+                </div>
+              </div>
+
+              <div className="overflow-y-auto max-h-[500px] space-y-3">
+                {filteredQueries.length === 0 ? (
+                  <div className="text-center py-8 text-muted-foreground">
+                    {searchTerm ? "No queries match your search" : "No saved queries yet"}
+                  </div>
+                ) : (
+                  filteredQueries.map((query) => (
+                    <Card key={query.id} className="cursor-pointer hover:bg-accent/50 transition-colors">
+                      <CardHeader className="pb-3">
+                        <div className="flex items-start justify-between">
+                          <CardTitle className="text-base">{query.description}</CardTitle>
+                          <div className="flex items-center gap-1">
+                            {query.isPublic && (
+                              <Badge variant="secondary" className="text-xs">
+                                Public
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                        <CardDescription className="flex items-center gap-4 text-xs">
+                          <span className="flex items-center gap-1">
+                            <UserIcon className="h-3 w-3" />
+                            {query.createdBy}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <CalendarIcon className="h-3 w-3" />
+                            {query.createdAt.toLocaleDateString()}
+                          </span>
+                        </CardDescription>
+                      </CardHeader>
+                      
+                      <CardContent className="pb-3 space-y-3">
+                        {/* Raw Query String */}
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-2 text-sm font-medium">
+                            <CodeIcon className="h-3 w-3" />
+                            Query Preview
+                          </div>
+                          <div className="bg-muted rounded-md p-3 text-xs font-mono overflow-x-auto">
+                            <pre className="whitespace-pre-wrap text-muted-foreground">
+                              {parseQueryToString(query)}
+                            </pre>
+                          </div>
+                        </div>
+                        
+                        {/* Tags */}
+                        {query.tags && query.tags.length > 0 && (
+                          <div className="flex items-center gap-1">
+                            <TagIcon className="h-3 w-3 text-muted-foreground" />
+                            <div className="flex gap-1 flex-wrap">
+                              {query.tags.map((tag) => (
+                                <Badge key={tag} variant="outline" className="text-xs">
+                                  {tag}
+                                </Badge>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </CardContent>
+
+                      <CardFooter className="pt-0">
+                        <Button 
+                          onClick={() => handleApplyQuery(query)}
+                          className="w-full"
+                          size="sm"
+                        >
+                          Apply Query
+                        </Button>
+                      </CardFooter>
+                    </Card>
+                  ))
+                )}
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="create" className="space-y-4">
+            <div className="py-6">
+              <h3 className="text-lg font-semibold mb-2">Save Current Query</h3>
+              <p className="text-muted-foreground mb-6">
+                Save your current filter, column, and sort configuration for future use
+              </p>
+              
+              {/* Current Query Preview */}
+              <div className="space-y-4 mb-6">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <CodeIcon className="h-4 w-4" />
+                  Current Query Preview
+                </div>
+                <div className="bg-muted rounded-md p-4 text-sm font-mono overflow-x-auto">
+                  <pre className="whitespace-pre-wrap text-muted-foreground">
+                    {getCurrentQueryString()}
+                  </pre>
+                </div>
+              </div>
+
+              <div className="space-y-3 text-sm">
+                <div>
+                  <strong>Current Configuration Summary:</strong>
+                </div>
+                <div>• Columns: {selectedColumns.join(", ") || "None selected"}</div>
+                <div>• Filters: {filterSelections.length} condition(s)</div>
+                {groupBySelection && (
+                  <div>• Grouped by: {groupBySelection.groupByColumn}</div>
+                )}
+                <div>• Sorting: {sorting.length} column(s)</div>
+              </div>
+
+              <Separator className="my-6" />
+              
+              <Button onClick={handleSaveCurrentQuery} className="w-full">
+                <PlusIcon className="h-4 w-4 mr-2" />
+                Save Current Query
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+} 

--- a/src/components/features/query/saved-queries.tsx
+++ b/src/components/features/query/saved-queries.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { PlusIcon, BookmarkIcon, SearchIcon, TagIcon, CalendarIcon, UserIcon, CodeIcon } from "lucide-react";
 import {
   Dialog,
@@ -12,13 +12,62 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Loading } from "@/components/ui/loading";
 import { useQuery } from "@/providers/query-provider";
+import { toast } from "sonner";
 import type { FirebaseQuery } from "@/lib/firebase/types";
+import { 
+  subscribeToSavedQueries, 
+  upsertSavedQuery, 
+  deleteSavedQuery 
+} from "@/services/saved-queries";
+
+const TABS = {
+  BROWSE: "browse",
+  CREATE: "create",
+} as const;
+
+const VALIDATION_ERRORS = {
+  DESCRIPTION_REQUIRED: "Please enter a description for your query",
+  DESCRIPTION_MIN_LENGTH: "Description must be at least 3 characters",
+  DESCRIPTION_MAX_LENGTH: "Description must be less than 100 characters",
+} as const;
+
+type TabValue = typeof TABS[keyof typeof TABS];
 
 interface SavedQueriesProps {
   children: React.ReactNode;
+}
+
+interface SaveFormState {
+  description: string;
+  tags: string;
+  isPublic: boolean;
+}
+
+interface ValidationError {
+  field: keyof SaveFormState;
+  message: string;
+}
+
+/**
+ * helper to validate form data
+ */
+function validateSaveForm(form: SaveFormState): ValidationError[] {
+  const errors: ValidationError[] = [];
+  
+  if (!form.description.trim()) {
+    errors.push({ field: 'description', message: VALIDATION_ERRORS.DESCRIPTION_REQUIRED });
+  } else if (form.description.trim().length < 3) {
+    errors.push({ field: 'description', message: VALIDATION_ERRORS.DESCRIPTION_MIN_LENGTH });
+  } else if (form.description.trim().length > 100) {
+    errors.push({ field: 'description', message: VALIDATION_ERRORS.DESCRIPTION_MAX_LENGTH });
+  }
+  
+  return errors;
 }
 
 /**
@@ -96,51 +145,16 @@ function getFilterOperatorSymbol(condition: string): string {
 export function SavedQueries({ children }: SavedQueriesProps) {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedTab, setSelectedTab] = useState("browse");
+  const [selectedTab, setSelectedTab] = useState<TabValue>(TABS.BROWSE);
+  const [savedQueries, setSavedQueries] = useState<FirebaseQuery[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   
-  // TODO: replace with actual Firebase data
-  const [savedQueries] = useState<FirebaseQuery[]>([
-          {
-        id: "1",
-        description: "Blacklisted applicants",
-        selectedColumns: ["firstName", "school", "major", "totalScore"],
-        filterSelections: [
-          {
-            id: "f1",
-            filterColumn: "totalScore",
-            filterCondition: "less_than",
-            filterValue: "0",
-          },
-        ],
-        groupBySelection: undefined,
-        sorting: [],
-        createdAt: new Date("2024-01-15"),
-        updatedAt: new Date("2024-01-15"),
-        createdBy: "user123",
-        isPublic: true,
-        tags: ["applicants"],
-      },
-    {
-      id: "2", 
-      description: "All accepted applicants",
-      selectedColumns: ["firstName", "email", "major", "totalScore"],
-      filterSelections: [
-        {
-          id: "f3",
-          filterColumn: "applicationStatus",
-          filterCondition: "equals",
-          filterValue: "acceptedNoResponseYet",
-        },
-      ],
-      groupBySelection: undefined,
-      sorting: [{ id: "totalScore", desc: true }],
-      createdAt: new Date("2024-01-10"),
-      updatedAt: new Date("2024-01-12"),
-      createdBy: "user456",
-      isPublic: false,
-      tags: ["accepted", "final"],
-    },
-  ]);
+  const [saveForm, setSaveForm] = useState<SaveFormState>({
+    description: "",
+    tags: "",
+    isPublic: false,
+  });
+  const [isSaving, setIsSaving] = useState(false);
 
   const {
     selectedColumns,
@@ -154,51 +168,129 @@ export function SavedQueries({ children }: SavedQueriesProps) {
     onSortingChange,
   } = useQuery();
 
-  const filteredQueries = savedQueries.filter(query =>
-    query.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    query.tags?.some(tag => tag.toLowerCase().includes(searchTerm.toLowerCase()))
-  );
+  useEffect(() => {
+    if (!open) return;
 
-  const handleApplyQuery = (query: FirebaseQuery) => {
-    filterSelections.forEach(filter => onFilterRemove(filter.id));
-    onGroupByChange(undefined);
-    onSortingChange([]);
+    setIsLoading(true);
+    let unsubscribe: (() => void) | null = null;
     
-    // TO-DO: need to optimize the provider to handle bulk updates more efficiently
-    query.filterSelections.forEach(filter => onFilterAdd(filter));
-    if (query.groupBySelection) {
-      onGroupByChange(query.groupBySelection);
+    try {
+      unsubscribe = subscribeToSavedQueries((queries) => {
+        setSavedQueries(queries);
+        setIsLoading(false);
+      });
+    } catch (error) {
+      console.error("Failed to subscribe to saved queries:", error);
+      setIsLoading(false);
+      toast.error("Failed to load saved queries");
     }
-    onSortingChange(query.sorting);
-    
-    // TO-DO: need to add/remove columns to match the saved selection
-    const currentColumns = new Set(selectedColumns);
-    const targetColumns = new Set(query.selectedColumns);
-    
-    selectedColumns.forEach(col => {
-      if (!targetColumns.has(col)) {
-        onColumnToggle(col);
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [open]);
+
+  const filteredQueries = useMemo(() => {
+    const searchLower = searchTerm.toLowerCase();
+    return savedQueries.filter(query =>
+      query.description?.toLowerCase().includes(searchLower) ||
+      query.tags?.some(tag => tag.toLowerCase().includes(searchLower))
+    );
+  }, [savedQueries, searchTerm]);
+
+  const handleApplyQuery = useCallback(async (query: FirebaseQuery) => {
+    try {
+      filterSelections.forEach(filter => onFilterRemove(filter.id));
+      onGroupByChange(undefined);
+      onSortingChange([]);
+      
+      query.filterSelections.forEach(filter => onFilterAdd(filter));
+      if (query.groupBySelection) {
+        onGroupByChange(query.groupBySelection);
       }
-    });
-    
-    query.selectedColumns.forEach(col => {
-      if (!currentColumns.has(col)) {
-        onColumnToggle(col);
+      onSortingChange(query.sorting);
+      
+      const currentColumns = new Set(selectedColumns);
+      const targetColumns = new Set(query.selectedColumns);
+      
+      selectedColumns.forEach(col => {
+        if (!targetColumns.has(col)) {
+          onColumnToggle(col);
+        }
+      });
+      
+      query.selectedColumns.forEach(col => {
+        if (!currentColumns.has(col)) {
+          onColumnToggle(col);
+        }
+      });
+      
+      setOpen(false);
+      toast.success(`Applied query: ${query.description}`);
+    } catch (error) {
+      toast.error("Failed to apply query");
+    }
+  }, [filterSelections, onFilterRemove, onGroupByChange, onSortingChange, selectedColumns, onColumnToggle]);
+
+  const handleSaveCurrentQuery = async () => {
+    const validationErrors = validateSaveForm(saveForm);
+    if (validationErrors.length > 0) {
+      toast.error(validationErrors[0].message);
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const tagsArray = saveForm.tags
+        .split(",")
+        .map(tag => tag.trim())
+        .filter(tag => tag.length > 0);
+
+      const queryToSave: any = {
+        description: saveForm.description.trim(),
+        selectedColumns,
+        filterSelections,
+        sorting,
+        isPublic: saveForm.isPublic,
+      };
+
+      if (groupBySelection) {
+        queryToSave.groupBySelection = groupBySelection;
       }
-    });
-    
-    setOpen(false);
+      
+      if (tagsArray.length > 0) {
+        queryToSave.tags = tagsArray;
+      }
+
+      await upsertSavedQuery(queryToSave);
+      
+      setSaveForm({
+        description: "",
+        tags: "",
+        isPublic: false,
+      });
+      
+      setSelectedTab(TABS.BROWSE);
+      toast.success("Query saved successfully!");
+    } catch (error) {
+      console.error("Error saving query:", error);
+      toast.error("Failed to save query");
+    } finally {
+      setIsSaving(false);
+    }
   };
 
-  const handleSaveCurrentQuery = () => {
-    // TODO: Create a new FirebaseQuery from current state
-    console.log("Save current query:", {
-      selectedColumns,
-      filterSelections,
-      groupBySelection,
-      sorting,
-    });
-  };
+  const handleDeleteQuery = useCallback(async (queryId: string) => {
+    try {
+      setSavedQueries(prev => prev.filter(query => query.id !== queryId));
+      
+      await deleteSavedQuery(queryId);
+      toast.success("Query deleted successfully");
+    } catch (error) {
+      console.error("Error deleting query:", error);
+      toast.error("Failed to delete query");
+    }
+  }, []);
 
   const getCurrentQueryString = (): string => {
     const currentQuery: FirebaseQuery = {
@@ -216,30 +308,39 @@ export function SavedQueries({ children }: SavedQueriesProps) {
     return parseQueryToString(currentQuery);
   };
 
+  const hasCurrentQueryData = selectedColumns.length > 0 || 
+    filterSelections.length > 0 || 
+    groupBySelection || 
+    sorting.length > 0;
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         {children}
       </DialogTrigger>
-      <DialogContent className="max-w-5xl max-h-[85vh] overflow-hidden">
+      <DialogContent className="max-w-5xl max-h-[90vh] overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <BookmarkIcon className="h-5 w-5" />
             Saved Queries
           </DialogTitle>
           <DialogDescription>
-            Browse, apply, and manage your saved query configurations
+            Browse, apply, and manage your saved queries.
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs value={selectedTab} onValueChange={setSelectedTab} className="flex-1 overflow-hidden">
+        <Tabs
+          value={selectedTab}
+          onValueChange={(value) => setSelectedTab(value as TabValue)}
+          className="flex-1 overflow-hidden justify-start"
+        >
           <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="browse">Browse Queries</TabsTrigger>
-            <TabsTrigger value="create">Save Current</TabsTrigger>
+            <TabsTrigger value={TABS.BROWSE}>Browse Queries</TabsTrigger>
+            <TabsTrigger value={TABS.CREATE}>Save Current</TabsTrigger>
           </TabsList>
-
-          <TabsContent value="browse" className="flex-1 overflow-hidden">
-            <div className="space-y-4 h-full">
+          
+          <TabsContent value={TABS.BROWSE} className="h-full flex-1">
+            <div className="space-y-4 h-auto">
               <div className="flex items-center gap-2">
                 <div className="relative flex-1">
                   <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -248,12 +349,17 @@ export function SavedQueries({ children }: SavedQueriesProps) {
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                     className="pl-10"
+                    aria-label="Search saved queries"
                   />
                 </div>
               </div>
 
-              <div className="overflow-y-auto max-h-[500px] space-y-3">
-                {filteredQueries.length === 0 ? (
+              <div className="overflow-y-auto max-h-full space-y-3">
+                {isLoading ? (
+                  <div className="flex items-center justify-center py-8">
+                    <Loading />
+                  </div>
+                ) : filteredQueries.length === 0 ? (
                   <div className="text-center py-8 text-muted-foreground">
                     {searchTerm ? "No queries match your search" : "No saved queries yet"}
                   </div>
@@ -269,6 +375,17 @@ export function SavedQueries({ children }: SavedQueriesProps) {
                                 Public
                               </Badge>
                             )}
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteQuery(query.id);
+                              }}
+                              className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
+                            >
+                              ×
+                            </Button>
                           </div>
                         </div>
                         <CardDescription className="flex items-center gap-4 text-xs">
@@ -284,7 +401,6 @@ export function SavedQueries({ children }: SavedQueriesProps) {
                       </CardHeader>
                       
                       <CardContent className="pb-3 space-y-3">
-                        {/* Raw Query String */}
                         <div className="space-y-2">
                           <div className="flex items-center gap-2 text-sm font-medium">
                             <CodeIcon className="h-3 w-3" />
@@ -297,7 +413,6 @@ export function SavedQueries({ children }: SavedQueriesProps) {
                           </div>
                         </div>
                         
-                        {/* Tags */}
                         {query.tags && query.tags.length > 0 && (
                           <div className="flex items-center gap-1">
                             <TagIcon className="h-3 w-3 text-muted-foreground" />
@@ -328,45 +443,78 @@ export function SavedQueries({ children }: SavedQueriesProps) {
             </div>
           </TabsContent>
 
-          <TabsContent value="create" className="space-y-4">
-            <div className="py-6">
-              <h3 className="text-lg font-semibold mb-2">Save Current Query</h3>
-              <p className="text-muted-foreground mb-6">
-                Save your current filter, column, and sort configuration for future use
-              </p>
-              
-              {/* Current Query Preview */}
-              <div className="space-y-4 mb-6">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <CodeIcon className="h-4 w-4" />
-                  Current Query Preview
+          <TabsContent value={TABS.CREATE} className="space-y-4 overflow-y-auto">
+              {!hasCurrentQueryData ? (
+                <div className="text-center mt-4 py-8 text-muted-foreground">
+                  <p>No query configuration to save.</p>
+                  <p className="text-sm">Set up some filters, select columns, or configure sorting first.</p>
                 </div>
-                <div className="bg-muted rounded-md p-4 text-sm font-mono overflow-x-auto">
-                  <pre className="whitespace-pre-wrap text-muted-foreground">
-                    {getCurrentQueryString()}
-                  </pre>
-                </div>
-              </div>
+              ) : (
+                <>
+                  <div className="space-y-4 mb-6 mt-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="description">Description *</Label>
+                      <Input
+                        id="description"
+                        placeholder="Ex. Number of RSVP'd hackers"
+                        value={saveForm.description}
+                        onChange={(e) => setSaveForm(prev => ({ ...prev, description: e.target.value }))}
+                      />
+                    </div>
+                    
+                    <div className="space-y-2">
+                      <Label htmlFor="tags">Tags (comma-separated)</Label>
+                      <Input
+                        id="tags"
+                        placeholder="e.g. accepted, nwHacks"
+                        value={saveForm.tags}
+                        onChange={(e) => setSaveForm(prev => ({ ...prev, tags: e.target.value }))}
+                      />
+                    </div>
+                    
+                    <div className="flex items-center space-x-2">
+                      <Switch
+                        id="isPublic"
+                        checked={saveForm.isPublic}
+                        onCheckedChange={(checked) => setSaveForm(prev => ({ ...prev, isPublic: checked }))}
+                      />
+                      <Label htmlFor="isPublic">Make this query public (visible to all organizers)</Label>
+                    </div>
+                  </div>
 
-              <div className="space-y-3 text-sm">
-                <div>
-                  <strong>Current Configuration Summary:</strong>
-                </div>
-                <div>• Columns: {selectedColumns.join(", ") || "None selected"}</div>
-                <div>• Filters: {filterSelections.length} condition(s)</div>
-                {groupBySelection && (
-                  <div>• Grouped by: {groupBySelection.groupByColumn}</div>
-                )}
-                <div>• Sorting: {sorting.length} column(s)</div>
-              </div>
-
-              <Separator className="my-6" />
-              
-              <Button onClick={handleSaveCurrentQuery} className="w-full">
-                <PlusIcon className="h-4 w-4 mr-2" />
-                Save Current Query
-              </Button>
-            </div>
+                  <div className="space-y-4 mb-6">
+                    <div className="flex items-center gap-2 text-sm font-medium">
+                      <CodeIcon className="h-4 w-4" />
+                      Current Query Preview
+                    </div>
+                    <div className="bg-muted rounded-md p-4 text-sm font-mono overflow-x-auto max-h-[140px]">
+                      <pre className="whitespace-pre-wrap text-muted-foreground">
+                        {getCurrentQueryString()}
+                      </pre>
+                    </div>
+                  </div>
+                  
+                  <Button 
+                    onClick={handleSaveCurrentQuery} 
+                    className="w-full"
+                    disabled={isSaving || !saveForm.description.trim()}
+                  >
+                    {isSaving ? (
+                      <>
+                        <div className="mr-2 h-4 w-4">
+                          <Loading />
+                        </div>
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <PlusIcon className="h-4 w-4 mr-2" />
+                        Save Current Query
+                      </>
+                    )}
+                  </Button>
+                </>
+              )}
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/lib/firebase/types.ts
+++ b/src/lib/firebase/types.ts
@@ -1,4 +1,5 @@
 import type { Timestamp } from "firebase/firestore";
+import type { SortingState } from "@tanstack/react-table";
 
 export type ApplicantMajor =
   | "computerScience"
@@ -395,6 +396,7 @@ export interface DevConfig {
   VerificationConfig?: VerificationConfig;
   TicketsConfig?: TicketsConfig;
 }
+
 export interface ContestQuestion {
   username: string;
   email: string;
@@ -403,4 +405,55 @@ export interface ContestQuestion {
   lastname: string;
   preferredname: string;
   phonenumber: string;
+}
+
+/** QUERY TYPES */
+export interface FirebaseQuery {
+  id: string;
+  description?: string;
+  selectedColumns: string[];
+  filterSelections: FilterRowsSelection[];
+  groupBySelection?: GroupBySelection;
+  sorting: SortingState;
+  createdAt: Date;
+  updatedAt: Date;
+  createdBy: string;
+  isPublic: boolean;
+  tags?: string[];
+}
+
+export type FilterCondition = "matches" | "does_not_match" | "equals" | "not_equals" | "greater_than" | "less_than";
+
+export type AggregationFunction = "COUNT" | "SUM" | "AVERAGE" | "MIN" | "MAX";
+
+export type ApplicantFieldValue = string | number | boolean | Date | null | Record<string, boolean> | undefined;
+
+export interface GroupBySelection {
+  groupByColumn: string;
+  aggregationFunction: string;
+  aggregationColumn: string;
+}
+
+export interface FilterRowsSelection {
+  id: string;
+  filterColumn: string;
+  filterCondition: string;
+  filterValue: string;
+  logicalOperator?: 'AND' | 'OR';
+}
+
+export interface SavedQueryCategory {
+  id: string;
+  name: string;
+  description?: string;
+  queries: FirebaseQuery[];
+}
+
+export interface QueryTemplate {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  query: Partial<FirebaseQuery>;
+  isSystemTemplate: boolean;
 }

--- a/src/providers/query-provider.tsx
+++ b/src/providers/query-provider.tsx
@@ -5,45 +5,14 @@ import type { SortingState } from "@tanstack/react-table";
 import type { FlattenedApplicant } from "@/services/query";
 import { subscribeToHackathons } from "@/lib/firebase/firestore";
 import { subscribeToApplicants, flattenApplicantData, calculateApplicantPoints } from "@/services/query";
-import type { Hackathon } from "@/lib/firebase/types";
-
-
-/**
- * Represents all possible filter operators that can be applied to a feature column. 
- */
-type FilterCondition = "matches" | "does_not_match" | "equals" | "not_equals" | "greater_than" | "less_than";
-
-/**
- * Represents all possible aggregation functions that can be applied to feature columns.
- */
-type AggregationFunction = "COUNT" | "SUM" | "AVERAGE" | "MIN" | "MAX";
-
-/**
- * Represents all possible value types that can exist in applicant data fields for type safety.
- */
-export type ApplicantFieldValue = string | number | boolean | Date | null | Record<string, boolean> | undefined;
-
-/**
- * Users can group by a column and apply an aggregation function to another column.
- * This interface represents these three selections.
- */
-export interface GroupBySelection {
-  groupByColumn: string;
-  aggregationFunction: string;
-  aggregationColumn: string;
-}
-
-/**
- * Users can filter the data based on a column and a condition.
- * This interface represents this selection.
- */
-export interface FilterRowsSelection {
-  id: string;
-  filterColumn: string;
-  filterCondition: string;
-  filterValue: string;
-  logicalOperator?: 'AND' | 'OR'; // To connect with the next condition 
-}
+import type { 
+  Hackathon, 
+  FilterCondition, 
+  AggregationFunction, 
+  ApplicantFieldValue, 
+  GroupBySelection, 
+  FilterRowsSelection 
+} from "@/lib/firebase/types";
 
 /**
  * Evaluates whether a single applicant field value satisfies a given filter condition.

--- a/src/routes/_auth/query.tsx
+++ b/src/routes/_auth/query.tsx
@@ -9,6 +9,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Raffle } from "@/components/features/query/raffle";
 import { ExportQuery } from "@/components/features/query/export";
 import { HackathonSelector } from "@/components/features/query/hackathon-selector";
+import { SavedQueries } from "@/components/features/query/saved-queries";
 import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/_auth/query")({
@@ -28,9 +29,11 @@ function QueryPage() {
               <div className="flex flex-col space-y-4 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
                 <HackathonSelector />
                 <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-3">
-                  <Button variant="outline">
-                    Saved Queries
-                  </Button>
+                  <SavedQueries>
+                    <Button variant="outline">
+                      Saved Queries
+                    </Button>
+                  </SavedQueries>
                   <ExportQuery />
                   <Raffle />
                 </div>

--- a/src/routes/_auth/query.tsx
+++ b/src/routes/_auth/query.tsx
@@ -9,6 +9,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Raffle } from "@/components/features/query/raffle";
 import { ExportQuery } from "@/components/features/query/export";
 import { HackathonSelector } from "@/components/features/query/hackathon-selector";
+import { Button } from "@/components/ui/button";
 
 export const Route = createFileRoute("/_auth/query")({
   component: QueryPage,
@@ -27,8 +28,11 @@ function QueryPage() {
               <div className="flex flex-col space-y-4 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
                 <HackathonSelector />
                 <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-3">
-                  <Raffle />
+                  <Button variant="outline">
+                    Saved Queries
+                  </Button>
                   <ExportQuery />
+                  <Raffle />
                 </div>
               </div>
 

--- a/src/routes/_auth/query.tsx
+++ b/src/routes/_auth/query.tsx
@@ -6,8 +6,7 @@ import { QueryTable } from "@/components/features/query/query-table";
 import { getAvailableColumns } from "@/services/query";
 import { QueryProvider } from "@/providers/query-provider";
 import { createFileRoute } from "@tanstack/react-router";
-import { Raffle } from "@/components/features/query/raffle";
-import { ExportQuery } from "@/components/features/query/export";
+import { QueryActions } from "@/components/features/query/query-actions";
 import { HackathonSelector } from "@/components/features/query/hackathon-selector";
 import { SavedQueries } from "@/components/features/query/saved-queries";
 import { Button } from "@/components/ui/button";
@@ -34,8 +33,7 @@ function QueryPage() {
                       Saved Queries
                     </Button>
                   </SavedQueries>
-                  <ExportQuery />
-                  <Raffle />
+                  <QueryActions />
                 </div>
               </div>
 

--- a/src/services/saved-queries.ts
+++ b/src/services/saved-queries.ts
@@ -1,0 +1,275 @@
+import { auth, db } from "@/lib/firebase/client";
+import type { FirebaseQuery } from "@/lib/firebase/types";
+import {
+  Timestamp,
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  query,
+  setDoc,
+  where,
+  orderBy,
+  getDoc,
+  getDocs,
+} from "firebase/firestore";
+
+/**
+ * Collection reference for saved queries
+ */
+const queriesCollection = () => collection(db, "InternalWebsites", "CMS", "queries");
+
+/**
+ * Utility function that returns saved queries collection realtime data
+ * @param callback - The function used to ingest the data
+ * @returns a function to be called on dismount
+ */
+export const subscribeToSavedQueries = (callback: (docs: FirebaseQuery[]) => void) =>
+  onSnapshot(
+    query(
+      queriesCollection(),
+      orderBy("updatedAt", "desc")
+    ),
+    (querySnapshot) => {
+      const queries: FirebaseQuery[] = [];
+      for (const docSnap of querySnapshot.docs) {
+        const data = docSnap.data();
+        queries.push({
+          ...data,
+          id: docSnap.id,
+          createdAt: data.createdAt?.toDate() || new Date(),
+          updatedAt: data.updatedAt?.toDate() || new Date(),
+        } as FirebaseQuery);
+      }
+      callback(queries);
+    },
+    (error) => {
+      console.error("Error fetching saved queries:", error);
+      callback([]);
+    }
+  );
+
+/**
+ * Utility function that returns public saved queries only
+ * @param callback - The function used to ingest the data
+ * @returns a function to be called on dismount
+ */
+export const subscribeToPublicSavedQueries = (callback: (docs: FirebaseQuery[]) => void) =>
+  onSnapshot(
+    query(
+      queriesCollection(),
+      where("isPublic", "==", true),
+      orderBy("updatedAt", "desc")
+    ),
+    (querySnapshot) => {
+      const queries: FirebaseQuery[] = [];
+      for (const docSnap of querySnapshot.docs) {
+        const data = docSnap.data();
+        queries.push({
+          ...data,
+          id: docSnap.id,
+          createdAt: data.createdAt?.toDate() || new Date(),
+          updatedAt: data.updatedAt?.toDate() || new Date(),
+        } as FirebaseQuery);
+      }
+      callback(queries);
+    },
+    (error) => {
+      console.error("Error fetching public saved queries:", error);
+      callback([]);
+    }
+  );
+
+/**
+ * Utility function that returns saved queries for the current user
+ * @param callback - The function used to ingest the data
+ * @returns a function to be called on dismount
+ */
+export const subscribeToUserSavedQueries = (callback: (docs: FirebaseQuery[]) => void) => {
+  const currentUserEmail = auth.currentUser?.email;
+  if (!currentUserEmail) {
+    callback([]);
+    return () => {};
+  }
+
+  return onSnapshot(
+    query(
+      queriesCollection(),
+      where("createdBy", "==", currentUserEmail),
+      orderBy("updatedAt", "desc")
+    ),
+    (querySnapshot) => {
+      const queries: FirebaseQuery[] = [];
+      for (const docSnap of querySnapshot.docs) {
+        const data = docSnap.data();
+        queries.push({
+          ...data,
+          id: docSnap.id,
+          createdAt: data.createdAt?.toDate() || new Date(),
+          updatedAt: data.updatedAt?.toDate() || new Date(),
+        } as FirebaseQuery);
+      }
+      callback(queries);
+    },
+    (error) => {
+      console.error("Error fetching user saved queries:", error);
+      callback([]);
+    }
+  );
+};
+
+/**
+ * Get a single saved query by ID
+ * @param queryId - The ID of the query to fetch
+ * @returns Promise<FirebaseQuery | null>
+ */
+export const getSavedQuery = async (queryId: string): Promise<FirebaseQuery | null> => {
+  try {
+    const docSnap = await getDoc(doc(queriesCollection(), queryId));
+    if (docSnap.exists()) {
+      const data = docSnap.data();
+      return {
+        ...data,
+        id: docSnap.id,
+        createdAt: data.createdAt?.toDate() || new Date(),
+        updatedAt: data.updatedAt?.toDate() || new Date(),
+      } as FirebaseQuery;
+    }
+    return null;
+  } catch (error) {
+    console.error("Error fetching saved query:", error);
+    throw error;
+  }
+};
+
+/**
+ * Utility function that updates or adds a saved query
+ * @param savedQuery - the saved query to update or insert
+ * @param id - if updating, ID of the saved query doc to update
+ */
+export const upsertSavedQuery = async (savedQuery: Omit<FirebaseQuery, 'id' | 'createdAt' | 'updatedAt' | 'createdBy'>, id?: string) => {
+  try {
+    const currentUser = auth.currentUser;
+    if (!currentUser?.email) {
+      throw new Error("User must be authenticated to save queries");
+    }
+
+    const now = Timestamp.now();
+    const record = {
+      updatedAt: now,
+      createdBy: currentUser.email,
+    };
+
+    const isNewDocument = !id;
+    if (isNewDocument) {
+      (record as any).createdAt = now;
+    }
+
+    const queryId = id || doc(queriesCollection()).id;
+    
+    const firestoreQuery = {
+      ...savedQuery,
+      ...record,
+    };
+
+    await setDoc(
+      doc(queriesCollection(), queryId),
+      firestoreQuery,
+      { merge: true }
+    );
+
+    return queryId;
+  } catch (error) {
+    console.error("Error saving query:", error);
+    throw error;
+  }
+};
+
+/**
+ * Utility function to delete a saved query
+ * @param id - the ID of the saved query document to delete
+ */
+export const deleteSavedQuery = async (id: string) => {
+  if (!id) return;
+  
+  try {
+    const currentUser = auth.currentUser;
+    if (!currentUser?.email) {
+      throw new Error("User must be authenticated to delete queries");
+    }
+
+    const queryDoc = await getSavedQuery(id);
+    if (queryDoc && queryDoc.createdBy !== currentUser.email) {
+      throw new Error("You can only delete your own saved queries");
+    }
+
+    await deleteDoc(doc(queriesCollection(), id));
+  } catch (error) {
+    console.error("Error deleting saved query:", error);
+    throw error;
+  }
+};
+
+/**
+ * Utility function to get saved queries by tag
+ * @param tag - the tag to filter by
+ * @returns Promise<FirebaseQuery[]>
+ */
+export const getSavedQueriesByTag = async (tag: string): Promise<FirebaseQuery[]> => {
+  try {
+    const querySnapshot = await getDocs(
+      query(
+        queriesCollection(),
+        where("tags", "array-contains", tag),
+        orderBy("updatedAt", "desc")
+      )
+    );
+
+    const queries: FirebaseQuery[] = [];
+    for (const docSnap of querySnapshot.docs) {
+      const data = docSnap.data();
+      queries.push({
+        ...data,
+        id: docSnap.id,
+        createdAt: data.createdAt?.toDate() || new Date(),
+        updatedAt: data.updatedAt?.toDate() || new Date(),
+      } as FirebaseQuery);
+    }
+
+    return queries;
+  } catch (error) {
+    console.error("Error fetching saved queries by tag:", error);
+    throw error;
+  }
+};
+
+/**
+ * Utility function to duplicate a saved query
+ * @param queryId - the ID of the query to duplicate
+ * @param newDescription - optional new description for the duplicated query
+ * @returns Promise<string> - the ID of the new duplicated query
+ */
+export const duplicateSavedQuery = async (queryId: string, newDescription?: string): Promise<string> => {
+  try {
+    const originalQuery = await getSavedQuery(queryId);
+    if (!originalQuery) {
+      throw new Error("Query not found");
+    }
+
+    const duplicatedQuery = {
+      ...originalQuery,
+      description: newDescription || `Copy of ${originalQuery.description}`,
+      isPublic: false, 
+    };
+
+    delete (duplicatedQuery as any).id;
+    delete (duplicatedQuery as any).createdAt;
+    delete (duplicatedQuery as any).updatedAt;
+    delete (duplicatedQuery as any).createdBy;
+
+    return await upsertSavedQuery(duplicatedQuery);
+  } catch (error) {
+    console.error("Error duplicating saved query:", error);
+    throw error;
+  }
+}; 

--- a/src/services/saved-queries.ts
+++ b/src/services/saved-queries.ts
@@ -155,14 +155,18 @@ export const upsertSavedQuery = async (savedQuery: Omit<FirebaseQuery, 'id' | 'c
     }
 
     const now = Timestamp.now();
-    const record = {
+    const record: {
+      updatedAt: Timestamp;
+      createdBy: string;
+      createdAt?: Timestamp;
+    } = {
       updatedAt: now,
       createdBy: currentUser.email,
     };
 
     const isNewDocument = !id;
     if (isNewDocument) {
-      (record as any).createdAt = now;
+      record.createdAt = now;
     }
 
     const queryId = id || doc(queriesCollection()).id;
@@ -256,16 +260,13 @@ export const duplicateSavedQuery = async (queryId: string, newDescription?: stri
       throw new Error("Query not found");
     }
 
+    const { id, createdAt, updatedAt, createdBy, ...queryData } = originalQuery;
+    
     const duplicatedQuery = {
-      ...originalQuery,
+      ...queryData,
       description: newDescription || `Copy of ${originalQuery.description}`,
       isPublic: false, 
     };
-
-    delete (duplicatedQuery as any).id;
-    delete (duplicatedQuery as any).createdAt;
-    delete (duplicatedQuery as any).updatedAt;
-    delete (duplicatedQuery as any).createdBy;
 
     return await upsertSavedQuery(duplicatedQuery);
   } catch (error) {


### PR DESCRIPTION
## Reason
getting rid of dev query tickets 

## Explanation
- Saved query dialog
- Allow organizers to browse and save query configurations privately/publicly (to other organizers)
<img width="1167" height="455" alt="Screenshot 2025-08-02 at 14 32 58" src="https://github.com/user-attachments/assets/1f208b6d-32e5-4806-a4af-dfd2d4fbdcc6" />
<img width="1420" height="879" alt="Screenshot 2025-08-02 at 14 36 57" src="https://github.com/user-attachments/assets/26e64dce-6f64-4a14-8a22-00ed211256c8" />
<img width="1422" height="879" alt="Screenshot 2025-08-02 at 14 34 55" src="https://github.com/user-attachments/assets/a13a491c-0179-4cbd-a3ed-808ae29e0694" />

## Other considerations
- Add validation for duplicate descriptions to reduce confusion in the future