### PR TITLE
added missing evaluator filter

### DIFF
--- a/src/components/features/evaluator/applicant-list.tsx
+++ b/src/components/features/evaluator/applicant-list.tsx
@@ -8,24 +8,18 @@ import { AcceptDialog } from "./accept-dialog";
 import { ApplicantEntry } from "./applicant-entry";
 import { CalculateDialog } from "./calculate-dialog";
 import type { ApplicationStatus } from "@/lib/firebase/types";
+import { STATUS_LABEL } from "@/components/features/evaluator/applicant-status";
 
+const EVALUATOR_STATUSES: ApplicationStatus[] = ["applied", "gradinginprog", "scored"];  
+const APPLICATION_STATUS_OPTIONS = EVALUATOR_STATUSES.map((status) => ({  
+  label: STATUS_LABEL[status]?.label || status,  
+  value: status,  
+}));  
 
 export function ApplicantList() {
   const { applicants, focusedApplicant, setFocusedApplicant } = useEvaluator();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedStatuses, setSelectedStatuses] = useState<ApplicationStatus[]>([]);
-
-
-  const applicationStatuses = [  
-    "gradinginprog",
-    "scored"
-  ].map((status) => ({ label: status, value: status })) as {
-    label: string;
-    value: ApplicationStatus;
-  }[];
-
-
-
 
   // using a useMemo for later when adding debounce
   const filteredApplicants = useMemo(() => {
@@ -43,7 +37,7 @@ export function ApplicantList() {
         <div className="flex items-center justify-between">
           <CardTitle className="pb-2">Applicant list</CardTitle>
           <MultiSelect
-            options={applicationStatuses}
+            options={APPLICATION_STATUS_OPTIONS}
             selected={selectedStatuses}
             onChange={(vals) => setSelectedStatuses(vals as ApplicationStatus[])}
             placeholder="Filter by..."

--- a/src/components/features/evaluator/applicant-list.tsx
+++ b/src/components/features/evaluator/applicant-list.tsx
@@ -71,12 +71,7 @@ export function ApplicantList() {
   }[];
 
 
- 
-  const filterApplicantsByStatus = (applicants: Applicant[], statuses:ApplicationStatus[]) : Applicant[] => {
-    if (!statuses.length) return applicants;
-    const wanted = new Set(statuses);
-    return applicants.filter((a) => a.status?.applicationStatus && wanted.has(a.status.applicationStatus));
-   }
+
 
   // using a useMemo for later when adding debounce
   const filteredApplicants = useMemo(() => {
@@ -158,3 +153,10 @@ export const filterApplicantsBySearch = (
     return searchWords.every((word) => fields.some((field) => field.includes(word)));
   });
 };
+
+ 
+const filterApplicantsByStatus = (applicants: Applicant[], statuses:ApplicationStatus[]) : Applicant[] => {
+  if (!statuses.length) return applicants;
+  const wanted = new Set(statuses);
+  return applicants.filter((a) => a.status?.applicationStatus && wanted.has(a.status.applicationStatus));
+ }

--- a/src/components/features/evaluator/applicant-list.tsx
+++ b/src/components/features/evaluator/applicant-list.tsx
@@ -1,27 +1,107 @@
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { MultiSelect } from "@/components/ui/multi-select";
 import type { Applicant } from "@/lib/firebase/types";
 import { useEvaluator } from "@/providers/evaluator-provider";
 import { useMemo, useState } from "react";
 import { AcceptDialog } from "./accept-dialog";
 import { ApplicantEntry } from "./applicant-entry";
 import { CalculateDialog } from "./calculate-dialog";
+import type { ApplicationStatus } from "@/lib/firebase/types";
+
 
 export function ApplicantList() {
   const { applicants, focusedApplicant, setFocusedApplicant } = useEvaluator();
   const [searchTerm, setSearchTerm] = useState("");
+  const [selectedStatuses, setSelectedStatuses] = useState<ApplicationStatus[]>([]);
+
+
+  // Experimenting with meta filters to group multiple statuses and match the applicant card colored status bubble
+
+  // type MetaFilter =
+  // | "Accepted:any"
+  // | "Grading:any"
+  // | "InProgress:any"
+  // | "Completed"
+  // | "Rejected"
+  // | "Waitlisted"
+  // | "Ungraded"
+  // | "Graded"; 
+
+  // const META_MAP: Record  <MetaFilter, ApplicationStatus[]> = {
+  //   "Accepted:any": [
+  //     "acceptedNoResponseYet",
+  //     "acceptedAndAttending",
+  //     "acceptedUnRSVP",
+  //   ],
+  //   "Waitlisted": ["waitlisted"],
+  //   "Rejected": ["rejected"],
+  //   "Graded" : ["scored"],
+  //   "Grading:any": ["gradinginprog"],
+  //   "Ungraded": ["applied"],
+  //   "InProgress:any": ["inProgress"],
+  //   "Completed": ["completed"],
+  // };
+
+  // const applicationStatuses = [
+  //   {label: "Accepted", value: "Accepted:any" as const},
+  //   {label: "Grading", value: "Grading:any" as const},
+  //   {label: "In Progress", value: "InProgress:any" as const},
+  //   {label: "Completed", value: "Completed" as const},
+  //   {label: "Rejected", value: "Rejected" as const},
+  //   {label: "Waitlisted", value: "Waitlisted" as const},
+  //   {label: "Ungraded", value: "Ungraded" as const},
+  //   {label: "Graded", value: "Graded" as const},
+  // ];
+
+  const applicationStatuses = [  
+    "inProgress",
+    "applied",
+    "gradinginprog",
+    "waitlisted",
+    "scored",
+    "rejected",
+    "completed",
+    "acceptedNoResponseYet",
+    "acceptedAndAttending",
+    "acceptedUnRSVP",
+  ].map((status) => ({ label: status, value: status })) as {
+    label: string;
+    value: ApplicationStatus;
+  }[];
+
+
+ 
+  const filterApplicantsByStatus = (applicants: Applicant[], statuses:ApplicationStatus[]) : Applicant[] => {
+    if (!statuses.length) return applicants;
+    const wanted = new Set(statuses);
+    return applicants.filter((a) => a.status?.applicationStatus && wanted.has(a.status.applicationStatus));
+   }
 
   // using a useMemo for later when adding debounce
   const filteredApplicants = useMemo(() => {
-    return filterApplicantsBySearch(applicants || [], searchTerm).sort((a, b) =>
+    let list = applicants || [];
+    list = filterApplicantsByStatus(list, selectedStatuses);
+    return filterApplicantsBySearch(list, searchTerm).sort((a, b) =>
       a._id.localeCompare(b._id),
     );
-  }, [applicants, searchTerm]);
+  }, [applicants, searchTerm, selectedStatuses]);
 
+ 
   return (
     <Card className="sticky top-[2vh] max-h-[96vh] rounded-xl">
       <CardHeader>
-        <CardTitle className="pb-2">Applicant list</CardTitle>
+        <div className="flex items-center justify-between">
+          <CardTitle className="pb-2">Applicant list</CardTitle>
+          <MultiSelect
+            options={applicationStatuses}
+            selected={selectedStatuses}
+            onChange={(vals) => setSelectedStatuses(vals as ApplicationStatus[])}
+            placeholder="Filter by..."
+            className="w-42"
+            />
+        </div>
+
         <Input
           value={searchTerm ?? ""}
           onChange={(e) => setSearchTerm(e.target.value)}

--- a/src/components/features/evaluator/applicant-list.tsx
+++ b/src/components/features/evaluator/applicant-list.tsx
@@ -16,55 +16,9 @@ export function ApplicantList() {
   const [selectedStatuses, setSelectedStatuses] = useState<ApplicationStatus[]>([]);
 
 
-  // Experimenting with meta filters to group multiple statuses and match the applicant card colored status bubble
-
-  // type MetaFilter =
-  // | "Accepted:any"
-  // | "Grading:any"
-  // | "InProgress:any"
-  // | "Completed"
-  // | "Rejected"
-  // | "Waitlisted"
-  // | "Ungraded"
-  // | "Graded"; 
-
-  // const META_MAP: Record  <MetaFilter, ApplicationStatus[]> = {
-  //   "Accepted:any": [
-  //     "acceptedNoResponseYet",
-  //     "acceptedAndAttending",
-  //     "acceptedUnRSVP",
-  //   ],
-  //   "Waitlisted": ["waitlisted"],
-  //   "Rejected": ["rejected"],
-  //   "Graded" : ["scored"],
-  //   "Grading:any": ["gradinginprog"],
-  //   "Ungraded": ["applied"],
-  //   "InProgress:any": ["inProgress"],
-  //   "Completed": ["completed"],
-  // };
-
-  // const applicationStatuses = [
-  //   {label: "Accepted", value: "Accepted:any" as const},
-  //   {label: "Grading", value: "Grading:any" as const},
-  //   {label: "In Progress", value: "InProgress:any" as const},
-  //   {label: "Completed", value: "Completed" as const},
-  //   {label: "Rejected", value: "Rejected" as const},
-  //   {label: "Waitlisted", value: "Waitlisted" as const},
-  //   {label: "Ungraded", value: "Ungraded" as const},
-  //   {label: "Graded", value: "Graded" as const},
-  // ];
-
   const applicationStatuses = [  
-    "inProgress",
-    "applied",
     "gradinginprog",
-    "waitlisted",
-    "scored",
-    "rejected",
-    "completed",
-    "acceptedNoResponseYet",
-    "acceptedAndAttending",
-    "acceptedUnRSVP",
+    "scored"
   ].map((status) => ({ label: status, value: status })) as {
     label: string;
     value: ApplicationStatus;

--- a/src/components/features/evaluator/applicant-status.tsx
+++ b/src/components/features/evaluator/applicant-status.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import type { ApplicationStatus } from "@/lib/firebase/types";
 import { cn } from "@/lib/utils";
 
-const STATUS_LABEL: Record<
+export const STATUS_LABEL: Record<
   ApplicationStatus,
   {
     label: string;

--- a/src/components/features/evaluator/applicant-status.tsx
+++ b/src/components/features/evaluator/applicant-status.tsx
@@ -26,7 +26,7 @@ export const STATUS_LABEL: Record<
     color: "bg-theme",
   },
   scored: {
-    label: "Graded",
+    label: "Scored",
     color: "bg-blue-500",
   },
   rejected: {


### PR DESCRIPTION
## Reason
<!--- Describe the motivation and purpose for this PR -->
Original figma design provided an option to filter applicants by status. 

## Explanation
<!--- Describe your changes! Include changes you made and screenshots/video if applicable -->

Added a multi select dropdown with all available applicant statuses. 

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->

- The little status bubble on the actual applicant cards groups multiple statuses into one (eg. the "Accepted" label is given to any applicant with "acceptedNoResponseYet","acceptedAndAttending","acceptedUnRSVP"). Can make it so that these are the only options in the dropdown. Not sure what we want/what would be easier. 