### PR TITLE
remove sponsor field in factotum discord questions

### DIFF
--- a/src/components/features/factotum/add-discord-questions.tsx
+++ b/src/components/features/factotum/add-discord-questions.tsx
@@ -42,16 +42,6 @@ export default function AddDiscordQuestions() {
       <h1 className="line-height-10 mb-5 font-bold text-2xl">Add Discord Questions</h1>
 
       <div className="flex gap-7">
-        <div>
-          <Label className="font-bold text-black text-lg">Sponsor</Label>
-          <p className="mb-2 text-black text-sm">Use official sponsor name</p>
-          <Input
-            className="border-2 border-gray-300 text-black focus-visible:border-gray-300"
-            onChange={(e) => setSponsor(e.target.value)}
-            value={sponsor}
-          />
-        </div>
-
         <div className="w-[40%]">
           <Label className="font-bold text-black text-lg">Question</Label>
           <p className="mb-2 text-black text-sm">What is the question?</p>

--- a/src/components/features/factotum/question-table.tsx
+++ b/src/components/features/factotum/question-table.tsx
@@ -35,9 +35,6 @@ export function QuestionTable() {
       header: "Modified by",
       cell: (info) => info.getValue(),
     }),
-    columnHelper.accessor("sponsor", {
-      header: "Sponsor",
-    }),
     columnHelper.accessor("question", {
       header: "Question",
     }),


### PR DESCRIPTION
## Reason
From ticket: https://www.notion.so/nwplus/Factotum-Remove-sponsor-field-from-discord-questions-26414d529faa804b9a60f0fc2458b24c?source=copy_link

## Explanation
Removed sponsor field when adding a discord question for factotum, and in the list of discord questions table.