### PR TITLE
fix: uses unique IDs for questions

### DIFF
--- a/src/components/features/hackerapp/hacker-app-section.tsx
+++ b/src/components/features/hackerapp/hacker-app-section.tsx
@@ -109,7 +109,11 @@ export function HackerAppSection({
    */
   const handleAddQuestion = useCallback(
     (index: number) =>
-      setData((data) => [...data.slice(0, index + 1), EMPTY_QUESTION, ...data.slice(index + 1)]),
+      setData((data) => [
+        ...data.slice(0, index + 1),
+        { _id: crypto.randomUUID(), ...EMPTY_QUESTION },
+        ...data.slice(index + 1),
+      ]),
     [],
   );
 


### PR DESCRIPTION
## Reason
<!--- Describe the motivation and purpose for this PR -->
IDs weren't passed to new question objects

## Explanation
<!--- Describe your changes! Include changes you made and screenshots/video if applicable -->
- adds a unique ID 

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
- confusing to use the indexes as IDs (a admin v1 design decision) -- may be best to just get rid of indexes as IDs and use a separate `order` field for the question objects