### PR TITLE
fix: Don't allow adding members if no roles/emails are provided + make mentor role values lowercase

### DIFF
--- a/src/components/features/factotum/add-members.tsx
+++ b/src/components/features/factotum/add-members.tsx
@@ -10,28 +10,28 @@ import { toast } from "sonner";
 export default function AddMembers() {
   const [emails, setEmails] = useState<string>("");
   const server = useFactotum().server;
-  const [selectedRoles, setSelectedRoles] = useState<string[]>(["Mentor"]);
+  const [selectedRoles, setSelectedRoles] = useState<string[]>(["mentor"]);
 
   const availableRoles = [
     {
       label: "Mentor",
-      value: "Mentor",
+      value: "mentor",
     },
     {
       label: "Sponsor",
-      value: "Sponsor",
+      value: "sponsor",
     },
     {
       label: "Volunteer",
-      value: "Volunteer",
+      value: "volunteer",
     },
     {
       label: "Photographer",
-      value: "Photographer",
+      value: "photographer",
     },
     {
       label: "Organizer",
-      value: "Organizer",
+      value: "organizer",
     },
   ];
 

--- a/src/components/features/factotum/add-members.tsx
+++ b/src/components/features/factotum/add-members.tsx
@@ -40,9 +40,15 @@ export default function AddMembers() {
       .split("\n")
       .map((e) => e.trim())
       .filter((e) => e.length > 0);
+    
+    if (emailList.length === 0 || selectedRoles.length === 0) {
+      toast.error("You must select at least one role and provide at least one email");
+      return;
+    }
+
     try {
       await addParticipants(emailList, selectedRoles, server);
-      toast("Participants added successfully");
+      toast.success("Participants added successfully");
     } catch (err) {
       toast.error("Failed to add participants");
       console.error(err);


### PR DESCRIPTION
We shouldn't be allowed to add members for verification if no role or email is provided
