### PR TITLE
Fix: Make blurb field optional for editing sponsors

### DIFF
--- a/src/components/features/sponsors/sponsor-dialog.tsx
+++ b/src/components/features/sponsors/sponsor-dialog.tsx
@@ -51,7 +51,7 @@ const SPONSOR_TIERS: { value: HackathonSponsorTiers; label: string }[] = [
 
 const formSchema = z.object({
   name: z.string().min(2).max(250),
-  blurb: z.string().min(2).max(500),
+  blurb: z.string().max(500).optional(),
   link: z.string().url("Please enter a valid URL"),
   tier: z.string().min(1, "Please select a tier"),
 });


### PR DESCRIPTION
straight to main for since hackcamp ppl need to add sponsors

## Reason
<!--- Describe the motivation and purpose for this PR -->

Not all sponsors have a blurb

## Explanation
<!--- Describe your changes! Include changes you made and screenshots/video if applicable -->

Made blurb optional in form schema